### PR TITLE
Symson dma32bits

### DIFF
--- a/C_Controller/include/compute_motor.h
+++ b/C_Controller/include/compute_motor.h
@@ -11,7 +11,7 @@ unsigned int compute_motor_press_christophe(
 		unsigned int step_t_ns_final,
 		unsigned int dec_ns,
 		unsigned int nb_steps, 
-		uint16_t* steps_t_us);
+		uint32_t* steps_t_us);
 
 void print_christophe_header(
 		unsigned int step_t_ns_init, 
@@ -24,9 +24,9 @@ void print_christophe_header(
 		int nb_steps);
 
 
-uint32_t compute_constant_motor_steps(uint16_t step_t_us, unsigned int nb_steps, uint16_t* steps_t_us);
+unsigned int compute_constant_motor_steps(uint32_t step_t_us, unsigned int nb_steps, uint32_t* steps_t_us);
 
-void print_steps(uint16_t* steps_t_us, unsigned int nb_steps);
+void print_steps(uint32_t* steps_t_us, unsigned int nb_steps);
 
 #endif //__COMPUTE_MOTOR_H__
 

--- a/C_Controller/include/platform.h
+++ b/C_Controller/include/platform.h
@@ -48,7 +48,7 @@ bool is_motor_ok();
 
 //! Press the BAVU to insufflate air to the patient according to the defined steps_profile in µs/step
 //! \warning motor driver is responsible to handle low-level errors in the best way to ensure corresponding action
-bool motor_press(uint16_t* steps_profile_us, uint16_t nb_steps);
+bool motor_press(uint32_t* steps_profile_us, unsigned int nb_steps);
 
 //! Release the BAVU to prepare next insufflation at any appropriate speed
 //! \param before_t_ms (in) timestamp before which motor should be in position to press BAVU again

--- a/C_Controller/include/platform.h
+++ b/C_Controller/include/platform.h
@@ -132,6 +132,9 @@ float read_Paw_cmH2O();
 //! \returns the atmospheric pressure in mbar
 float read_Patmo_mbar();
 
+//! \returns the atmospheric pressure in mbar
+float read_temp_degreeC();
+
 //! \returns the current integrated volume
 float read_Vol_mL();
 

--- a/C_Controller/platforms/recovid_revB/CMakeLists.txt
+++ b/C_Controller/platforms/recovid_revB/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(platform OBJECT
     indicators.c
     pep_valve.c
     gpio.c
+    bmp280.c
 )
 
 target_include_directories(platform PUBLIC 

--- a/C_Controller/platforms/recovid_revB/Toolchain.cmake
+++ b/C_Controller/platforms/recovid_revB/Toolchain.cmake
@@ -72,6 +72,11 @@ set(HAL_CFLAGS "\
 set(HAL_LFLAGS "\
     -T${LINKER_SCRIPT} \
 ")
+set(BMP280_CFLAGS "\
+	-DBMP280_DISABLE_64BIT_COMPENSATION \
+	-DBMP280_DISABLE_DOUBLE_COMPENSATION \
+")
+
 
 
 # May not work on old openocd versions
@@ -81,7 +86,7 @@ set(OPENOCD_CFG board/st_nucleo_f3.cfg)
 # Conclusion
 
 
-set(CMAKE_C_FLAGS   "${COMMON_TOOLCHAIN_CFLAGS} ${HAL_CFLAGS} -std=gnu99"
+set(CMAKE_C_FLAGS   "${COMMON_TOOLCHAIN_CFLAGS} ${HAL_CFLAGS} ${BMP280_CFLAGS} -std=gnu99"
     CACHE INTERNAL "c flags")
 set(CMAKE_CXX_FLAGS "${COMMON_TOOLCHAIN_CFLAGS} ${HAL_CFLAGS} -std=gnu++11"
     CACHE INTERNAL "c++ flags")

--- a/C_Controller/platforms/recovid_revB/bmp280.c
+++ b/C_Controller/platforms/recovid_revB/bmp280.c
@@ -1,0 +1,803 @@
+/**
+* Copyright (c) 2020 Bosch Sensortec GmbH. All rights reserved.
+*
+* BSD-3-Clause
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+* IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* @file	bmp280.c
+* @date	2020-01-10
+* @version	v3.3.4
+*
+*/#include "bmp280.h"
+
+/********************** Static function declarations ************************/
+
+/*!
+ * @brief This internal API is used to check for null-pointers in the device
+ * structure.
+ *
+ * @param[in] dev : Structure instance of bmp280_dev.
+ *
+ * @return Result of API execution status
+ * @retval Zero for Success, non-zero otherwise.
+ */
+static int8_t null_ptr_check(const struct bmp280_dev *dev);
+
+/*!
+ * @brief This internal API interleaves the register addresses and respective
+ * register data for a burst write
+ *
+ * @param[in] reg_addr: Register address array
+ * @param[out] temp_buff: Interleaved register address and data array
+ * @param[in] reg_addr: Register data array
+ * @param[in] len : Length of the reg_addr and reg_data arrays
+ *
+ * @return Result of API execution status
+ * @retval Zero for Success, non-zero otherwise.
+ */
+static void interleave_data(const uint8_t *reg_addr, uint8_t *temp_buff, const uint8_t *reg_data, uint8_t len);
+
+/*!
+ * @brief This API is used to read the calibration parameters used
+ * for calculating the compensated data.
+ *
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+static int8_t get_calib_param(struct bmp280_dev *dev);
+
+/*!
+ * @brief This internal API to reset the sensor, restore/set conf, restore/set mode
+ *
+ * @param[in] mode: Desired mode
+ * @param[in] conf : Desired configuration to the bmp280
+ * conf.os_temp, conf.os_pres = BMP280_OS_NONE, BMP280_OS_1X,
+ *     BMP280_OS_2X, BMP280_OS_4X, BMP280_OS_8X, BMP280_OS_16X
+ * conf.mode = BMP280_SLEEP_MODE, BMP280_FORCED_MODE, BMP280_NORMAL_MODE
+ * conf.odr = BMP280_ODR_0_5_MS, BMP280_ODR_62_5_MS, BMP280_ODR_125_MS,
+ *     BMP280_ODR_250_MS, BMP280_ODR_500_MS, BMP280_ODR_1000_MS,
+ *     BMP280_ODR_2000_MS, BMP280_ODR_4000_MS
+ * conf.filter = BMP280_FILTER_OFF, BMP280_FILTER_COEFF_2,
+ *     BMP280_FILTER_COEFF_4, BMP280_FILTER_COEFF_8, BMP280_FILTER_COEFF_16
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution status
+ * @retval Zero for Success, non-zero otherwise.
+ */
+static int8_t conf_sensor(uint8_t mode, const struct bmp280_config *conf, struct bmp280_dev *dev);
+
+/*!
+ * @This internal API checks whether the uncompensated temperature and pressure are within the range
+ *
+ * @param[in] utemperature : uncompensated temperature
+ * @param[in] upressure : uncompensated pressure
+ *
+ * @return Result of API execution status
+ * @retval Zero for Success, non-zero otherwise.
+ */
+static int8_t st_check_boundaries(int32_t utemperature, int32_t upressure);
+
+/****************** User Function Definitions *******************************/
+
+/*!
+ * @brief This API reads the data from the given register address of the
+ * sensor.
+ */
+int8_t bmp280_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint8_t len, const struct bmp280_dev *dev)
+{
+    int8_t rslt;
+
+    rslt = null_ptr_check(dev);
+    if ((rslt == BMP280_OK) && (reg_data != NULL))
+    {
+        /* Mask the register address' MSB if interface selected is SPI */
+        if (dev->intf == BMP280_SPI_INTF)
+        {
+            reg_addr = reg_addr | 0x80;
+        }
+        rslt = dev->read(dev->dev_id, reg_addr, reg_data, len);
+
+        /* Check for communication error and mask with an internal error code */
+        if (rslt != BMP280_OK)
+        {
+            rslt = BMP280_E_COMM_FAIL;
+        }
+    }
+    else
+    {
+        rslt = BMP280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API writes the given data to the register addresses
+ * of the sensor.
+ */
+int8_t bmp280_set_regs(uint8_t *reg_addr, const uint8_t *reg_data, uint8_t len, const struct bmp280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t temp_buff[8]; /* Typically not to write more than 4 registers */
+    uint16_t temp_len;
+    uint8_t reg_addr_cnt;
+
+    if (len > 4)
+    {
+        len = 4;
+    }
+    rslt = null_ptr_check(dev);
+    if ((rslt == BMP280_OK) && (reg_addr != NULL) && (reg_data != NULL))
+    {
+        if (len != 0)
+        {
+            temp_buff[0] = reg_data[0];
+
+            /* Mask the register address' MSB if interface selected is SPI */
+            if (dev->intf == BMP280_SPI_INTF)
+            {
+                /* Converting all the reg address into proper SPI write address
+                 * i.e making MSB(R/`W) bit 0
+                 */
+                for (reg_addr_cnt = 0; reg_addr_cnt < len; reg_addr_cnt++)
+                {
+                    reg_addr[reg_addr_cnt] = reg_addr[reg_addr_cnt] & 0x7F;
+                }
+            }
+
+            /* Burst write mode */
+            if (len > 1)
+            {
+                /* Interleave register address w.r.t data for burst write*/
+                interleave_data(reg_addr, temp_buff, reg_data, len);
+                temp_len = ((len * 2) - 1);
+            }
+            else
+            {
+                temp_len = len;
+            }
+            rslt = dev->write(dev->dev_id, reg_addr[0], temp_buff, temp_len);
+
+            /* Check for communication error and mask with an internal error code */
+            if (rslt != BMP280_OK)
+            {
+                rslt = BMP280_E_COMM_FAIL;
+            }
+        }
+        else
+        {
+            rslt = BMP280_E_INVALID_LEN;
+        }
+    }
+    else
+    {
+        rslt = BMP280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API triggers the soft reset of the sensor.
+ */
+int8_t bmp280_soft_reset(const struct bmp280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t reg_addr = BMP280_SOFT_RESET_ADDR;
+    uint8_t soft_rst_cmd = BMP280_SOFT_RESET_CMD;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        rslt = bmp280_set_regs(&reg_addr, &soft_rst_cmd, 1, dev);
+
+        /* As per the datasheet, startup time is 2 ms. */
+        dev->delay_ms(2);
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API is the entry point.
+ * It reads the chip-id and calibration data from the sensor.
+ */
+int8_t bmp280_init(struct bmp280_dev *dev)
+{
+    int8_t rslt;
+
+    /* Maximum number of tries before timeout */
+    uint8_t try_count = 5;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        while (try_count)
+        {
+            rslt = bmp280_get_regs(BMP280_CHIP_ID_ADDR, &dev->chip_id, 1, dev);
+
+            /* Check for chip id validity */
+            if ((rslt == BMP280_OK) &&
+                (dev->chip_id == BMP280_CHIP_ID1 || dev->chip_id == BMP280_CHIP_ID2 || dev->chip_id == BMP280_CHIP_ID3))
+            {
+                rslt = bmp280_soft_reset(dev);
+                if (rslt == BMP280_OK)
+                {
+                    rslt = get_calib_param(dev);
+                }
+                break;
+            }
+
+            /* Wait for 10 ms */
+            dev->delay_ms(10);
+            --try_count;
+        }
+
+        /* Chip id check failed, and timed out */
+        if (!try_count)
+        {
+            rslt = BMP280_E_DEV_NOT_FOUND;
+        }
+        if (rslt == BMP280_OK)
+        {
+            /* Set values to default */
+            dev->conf.filter = BMP280_FILTER_OFF;
+            dev->conf.os_pres = BMP280_OS_NONE;
+            dev->conf.os_temp = BMP280_OS_NONE;
+            dev->conf.odr = BMP280_ODR_0_5_MS;
+            dev->conf.spi3w_en = BMP280_SPI3_WIRE_DISABLE;
+        }
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API reads the data from the ctrl_meas register and config
+ * register. It gives the currently set temperature and pressure over-sampling
+ * configuration, power mode configuration, sleep duration and
+ * IIR filter coefficient.
+ */
+int8_t bmp280_get_config(struct bmp280_config *conf, struct bmp280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t temp[2] = { 0, 0 };
+
+    rslt = null_ptr_check(dev);
+    if ((rslt == BMP280_OK) && (conf != NULL))
+    {
+        rslt = bmp280_get_regs(BMP280_CTRL_MEAS_ADDR, temp, 2, dev);
+        if (rslt == BMP280_OK)
+        {
+            conf->os_temp = BMP280_GET_BITS(BMP280_OS_TEMP, temp[0]);
+            conf->os_pres = BMP280_GET_BITS(BMP280_OS_PRES, temp[0]);
+            conf->odr = BMP280_GET_BITS(BMP280_STANDBY_DURN, temp[1]);
+            conf->filter = BMP280_GET_BITS(BMP280_FILTER, temp[1]);
+            conf->spi3w_en = BMP280_GET_BITS_POS_0(BMP280_SPI3_ENABLE, temp[1]);
+            dev->conf = *conf;
+        }
+    }
+    else
+    {
+        rslt = BMP280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API writes the data to the ctrl_meas register and config register.
+ * It sets the temperature and pressure over-sampling configuration,
+ * power mode configuration, sleep duration and IIR filter coefficient.
+ */
+int8_t bmp280_set_config(const struct bmp280_config *conf, struct bmp280_dev *dev)
+{
+    return conf_sensor(BMP280_SLEEP_MODE, conf, dev);
+}
+
+/*!
+ * @brief This API reads the status register
+ */
+int8_t bmp280_get_status(struct bmp280_status *status, const struct bmp280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t temp;
+
+    rslt = null_ptr_check(dev);
+    if ((rslt == BMP280_OK) && (status != NULL))
+    {
+        rslt = bmp280_get_regs(BMP280_STATUS_ADDR, &temp, 1, dev);
+        status->measuring = BMP280_GET_BITS(BMP280_STATUS_MEAS, temp);
+        status->im_update = BMP280_GET_BITS_POS_0(BMP280_STATUS_IM_UPDATE, temp);
+    }
+    else
+    {
+        rslt = BMP280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API reads the power mode.
+ */
+int8_t bmp280_get_power_mode(uint8_t *mode, const struct bmp280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t temp;
+
+    rslt = null_ptr_check(dev);
+    if ((rslt == BMP280_OK) && (mode != NULL))
+    {
+        rslt = bmp280_get_regs(BMP280_CTRL_MEAS_ADDR, &temp, 1, dev);
+        *mode = BMP280_GET_BITS_POS_0(BMP280_POWER_MODE, temp);
+    }
+    else
+    {
+        rslt = BMP280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API writes the power mode.
+ */
+int8_t bmp280_set_power_mode(uint8_t mode, struct bmp280_dev *dev)
+{
+    int8_t rslt;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        rslt = conf_sensor(mode, &dev->conf, dev);
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API reads the temperature and pressure data registers.
+ * It gives the raw temperature and pressure data .
+ */
+int8_t bmp280_get_uncomp_data(struct bmp280_uncomp_data *uncomp_data, const struct bmp280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t temp[6] = { 0 };
+
+    rslt = null_ptr_check(dev);
+    if ((rslt == BMP280_OK) && (uncomp_data != NULL))
+    {
+        rslt = bmp280_get_regs(BMP280_PRES_MSB_ADDR, temp, 6, dev);
+        if (rslt == BMP280_OK)
+        {
+            uncomp_data->uncomp_press =
+                (int32_t) ((((uint32_t) (temp[0])) << 12) | (((uint32_t) (temp[1])) << 4) | ((uint32_t) temp[2] >> 4));
+            uncomp_data->uncomp_temp =
+                (int32_t) ((((int32_t) (temp[3])) << 12) | (((int32_t) (temp[4])) << 4) | (((int32_t) (temp[5])) >> 4));
+            rslt = st_check_boundaries((int32_t)uncomp_data->uncomp_temp, (int32_t)uncomp_data->uncomp_press);
+        }
+        else
+        {
+            rslt = BMP280_E_UNCOMP_DATA_CALC;
+        }
+    }
+    else
+    {
+        rslt = BMP280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API is used to get the compensated temperature from
+ * uncompensated temperature. This API uses 32 bit integers.
+ */
+int8_t bmp280_get_comp_temp_32bit(int32_t *comp_temp, int32_t uncomp_temp, struct bmp280_dev *dev)
+{
+    int32_t var1, var2;
+    int8_t rslt;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        var1 =
+            ((((uncomp_temp / 8) - ((int32_t) dev->calib_param.dig_t1 << 1))) * ((int32_t) dev->calib_param.dig_t2)) /
+            2048;
+        var2 =
+            (((((uncomp_temp / 16) - ((int32_t) dev->calib_param.dig_t1)) *
+               ((uncomp_temp / 16) - ((int32_t) dev->calib_param.dig_t1))) / 4096) *
+             ((int32_t) dev->calib_param.dig_t3)) /
+            16384;
+        dev->calib_param.t_fine = var1 + var2;
+        *comp_temp = (dev->calib_param.t_fine * 5 + 128) / 256;
+        rslt = BMP280_OK;
+    }
+    else
+    {
+        *comp_temp = 0;
+        rslt = BMP280_E_32BIT_COMP_TEMP;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API is used to get the compensated pressure from
+ * uncompensated pressure. This API uses 32 bit integers.
+ */
+int8_t bmp280_get_comp_pres_32bit(uint32_t *comp_pres, uint32_t uncomp_pres, const struct bmp280_dev *dev)
+{
+    int32_t var1, var2;
+    int8_t rslt;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        var1 = (((int32_t) dev->calib_param.t_fine) / 2) - (int32_t) 64000;
+        var2 = (((var1 / 4) * (var1 / 4)) / 2048) * ((int32_t) dev->calib_param.dig_p6);
+        var2 = var2 + ((var1 * ((int32_t) dev->calib_param.dig_p5)) * 2);
+        var2 = (var2 / 4) + (((int32_t) dev->calib_param.dig_p4) * 65536);
+        var1 =
+            (((dev->calib_param.dig_p3 * (((var1 / 4) * (var1 / 4)) / 8192)) / 8) +
+             ((((int32_t) dev->calib_param.dig_p2) * var1) / 2)) / 262144;
+        var1 = ((((32768 + var1)) * ((int32_t) dev->calib_param.dig_p1)) / 32768);
+        *comp_pres = (uint32_t)(((int32_t)(1048576 - uncomp_pres) - (var2 / 4096)) * 3125);
+
+        /* Avoid exception caused by division with zero */
+        if (var1 != 0)
+        {
+            /* Check for overflows against UINT32_MAX/2; if pres is left-shifted by 1 */
+            if (*comp_pres < 0x80000000)
+            {
+                *comp_pres = (*comp_pres << 1) / ((uint32_t) var1);
+            }
+            else
+            {
+                *comp_pres = (*comp_pres / (uint32_t) var1) * 2;
+            }
+            var1 = (((int32_t) dev->calib_param.dig_p9) * ((int32_t) (((*comp_pres / 8) * (*comp_pres / 8)) / 8192))) /
+                   4096;
+            var2 = (((int32_t) (*comp_pres / 4)) * ((int32_t) dev->calib_param.dig_p8)) / 8192;
+            *comp_pres = (uint32_t) ((int32_t) *comp_pres + ((var1 + var2 + dev->calib_param.dig_p7) / 16));
+            rslt = BMP280_OK;
+        }
+        else
+        {
+            *comp_pres = 0;
+            rslt = BMP280_E_32BIT_COMP_PRESS;
+        }
+    }
+
+    return rslt;
+}
+
+#ifndef BMP280_DISABLE_64BIT_COMPENSATION
+
+/*!
+ * @brief This API is used to get the compensated pressure from
+ * uncompensated pressure. This API uses 64 bit integers.
+ */
+int8_t bmp280_get_comp_pres_64bit(uint32_t *pressure, uint32_t uncomp_pres, const struct bmp280_dev *dev)
+{
+    int64_t var1, var2, p;
+    int8_t rslt;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        var1 = ((int64_t) (dev->calib_param.t_fine)) - 128000;
+        var2 = var1 * var1 * (int64_t) dev->calib_param.dig_p6;
+        var2 = var2 + ((var1 * (int64_t) dev->calib_param.dig_p5) * 131072);
+        var2 = var2 + (((int64_t) dev->calib_param.dig_p4) * 34359738368);
+        var1 = ((var1 * var1 * (int64_t) dev->calib_param.dig_p3) / 256) +
+               ((var1 * (int64_t) dev->calib_param.dig_p2) * 4096);
+        var1 = ((INT64_C(0x800000000000) + var1) * ((int64_t)dev->calib_param.dig_p1)) / 8589934592;
+        if (var1 != 0)
+        {
+            p = 1048576 - uncomp_pres;
+            p = (((((p * 2147483648U)) - var2) * 3125) / var1);
+            var1 = (((int64_t) dev->calib_param.dig_p9) * (p / 8192) * (p / 8192)) / 33554432;
+            var2 = (((int64_t) dev->calib_param.dig_p8) * p) / 524288;
+            p = ((p + var1 + var2) / 256) + (((int64_t)dev->calib_param.dig_p7) * 16);
+            *pressure = (uint32_t)p;
+            rslt = BMP280_OK;
+        }
+        else
+        {
+            *pressure = 0;
+            rslt = BMP280_E_64BIT_COMP_PRESS;
+        }
+    }
+
+    return rslt;
+}
+
+#endif /* BMP280_DISABLE_64BIT_COMPENSATION */
+
+#ifndef BMP280_DISABLE_DOUBLE_COMPENSATION
+
+/*!
+ * @brief This API is used to get the compensated temperature from
+ * uncompensated temperature. This API uses double floating precision.
+ */
+int8_t bmp280_get_comp_temp_double(double *temperature, int32_t uncomp_temp, struct bmp280_dev *dev)
+{
+    double var1, var2;
+    int8_t rslt;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        var1 = (((double) uncomp_temp) / 16384.0 - ((double) dev->calib_param.dig_t1) / 1024.0) *
+               ((double) dev->calib_param.dig_t2);
+        var2 =
+            ((((double) uncomp_temp) / 131072.0 - ((double) dev->calib_param.dig_t1) / 8192.0) *
+             (((double) uncomp_temp) / 131072.0 - ((double) dev->calib_param.dig_t1) / 8192.0)) *
+            ((double) dev->calib_param.dig_t3);
+        dev->calib_param.t_fine = (int32_t) (var1 + var2);
+        *temperature = ((var1 + var2) / 5120.0);
+    }
+    else
+    {
+        *temperature = 0;
+        rslt = BMP280_E_DOUBLE_COMP_TEMP;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This API is used to get the compensated pressure from
+ * uncompensated pressure. This API uses double floating precision.
+ */
+int8_t bmp280_get_comp_pres_double(double *pressure, uint32_t uncomp_pres, const struct bmp280_dev *dev)
+{
+    double var1, var2;
+    int8_t rslt;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        var1 = ((double) dev->calib_param.t_fine / 2.0) - 64000.0;
+        var2 = var1 * var1 * ((double) dev->calib_param.dig_p6) / 32768.0;
+        var2 = var2 + var1 * ((double) dev->calib_param.dig_p5) * 2.0;
+        var2 = (var2 / 4.0) + (((double) dev->calib_param.dig_p4) * 65536.0);
+        var1 = (((double)dev->calib_param.dig_p3) * var1 * var1 / 524288.0 + ((double)dev->calib_param.dig_p2) * var1) /
+               524288.0;
+        var1 = (1.0 + var1 / 32768.0) * ((double) dev->calib_param.dig_p1);
+
+        *pressure = 1048576.0 - (double)uncomp_pres;
+        if (var1 < 0 || var1 > 0)
+        {
+            *pressure = (*pressure - (var2 / 4096.0)) * 6250.0 / var1;
+            var1 = ((double)dev->calib_param.dig_p9) * (*pressure) * (*pressure) / 2147483648.0;
+            var2 = (*pressure) * ((double)dev->calib_param.dig_p8) / 32768.0;
+            *pressure = *pressure + (var1 + var2 + ((double)dev->calib_param.dig_p7)) / 16.0;
+        }
+        else
+        {
+            *pressure = 0;
+            rslt = BMP280_E_DOUBLE_COMP_PRESS;
+        }
+    }
+
+    return rslt;
+}
+
+#endif /* BMP280_DISABLE_DOUBLE_COMPENSATION */
+
+/*!
+ * @brief This API computes the measurement time in milliseconds for the
+ * active configuration
+ */
+uint8_t bmp280_compute_meas_time(const struct bmp280_dev *dev)
+{
+    uint32_t period = 0;
+    uint32_t t_dur = 0, p_dur = 0, p_startup = 0;
+    const uint32_t startup = 1000, period_per_osrs = 2000; /* Typical timings in us. Maximum is +15% each */
+    int8_t rslt;
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        t_dur = period_per_osrs * ((UINT32_C(1) << dev->conf.os_temp) >> 1);
+        p_dur = period_per_osrs * ((UINT32_C(1) << dev->conf.os_pres) >> 1);
+        p_startup = (dev->conf.os_pres) ? 500 : 0;
+
+        /* Increment the value to next highest integer if greater than 0.5 */
+        period = startup + t_dur + p_startup + p_dur + 500;
+        period /= 1000; /* Convert to milliseconds */
+    }
+
+    return (uint8_t)period;
+}
+
+/****************** Static Function Definitions *******************************/
+
+/*!
+ * @brief This internal API is used to check for null-pointers in the device
+ * structure.
+ */
+static int8_t null_ptr_check(const struct bmp280_dev *dev)
+{
+    int8_t rslt;
+
+    if ((dev == NULL) || (dev->read == NULL) || (dev->write == NULL) || (dev->delay_ms == NULL))
+    {
+        /* Null-pointer found */
+        rslt = BMP280_E_NULL_PTR;
+    }
+    else
+    {
+        rslt = BMP280_OK;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This internal API interleaves the register addresses and respective
+ * register data for a burst write
+ */
+static void interleave_data(const uint8_t *reg_addr, uint8_t *temp_buff, const uint8_t *reg_data, uint8_t len)
+{
+    uint8_t index;
+
+    for (index = 1; index < len; index++)
+    {
+        temp_buff[(index * 2) - 1] = reg_addr[index];
+        temp_buff[index * 2] = reg_data[index];
+    }
+}
+
+/*!
+ * @brief This API is used to read the calibration parameters used
+ * for calculating the compensated data.
+ */
+static int8_t get_calib_param(struct bmp280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t temp[BMP280_CALIB_DATA_SIZE] = { 0 };
+
+    rslt = null_ptr_check(dev);
+    if (rslt == BMP280_OK)
+    {
+        rslt = bmp280_get_regs(BMP280_DIG_T1_LSB_ADDR, temp, BMP280_CALIB_DATA_SIZE, dev);
+        if (rslt == BMP280_OK)
+        {
+            dev->calib_param.dig_t1 =
+                (uint16_t) (((uint16_t) temp[BMP280_DIG_T1_MSB_POS] << 8) | ((uint16_t) temp[BMP280_DIG_T1_LSB_POS]));
+            dev->calib_param.dig_t2 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_T2_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_T2_LSB_POS]));
+            dev->calib_param.dig_t3 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_T3_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_T3_LSB_POS]));
+            dev->calib_param.dig_p1 =
+                (uint16_t) (((uint16_t) temp[BMP280_DIG_P1_MSB_POS] << 8) | ((uint16_t) temp[BMP280_DIG_P1_LSB_POS]));
+            dev->calib_param.dig_p2 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_P2_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_P2_LSB_POS]));
+            dev->calib_param.dig_p3 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_P3_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_P3_LSB_POS]));
+            dev->calib_param.dig_p4 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_P4_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_P4_LSB_POS]));
+            dev->calib_param.dig_p5 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_P5_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_P5_LSB_POS]));
+            dev->calib_param.dig_p6 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_P6_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_P6_LSB_POS]));
+            dev->calib_param.dig_p7 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_P7_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_P7_LSB_POS]));
+            dev->calib_param.dig_p8 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_P8_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_P8_LSB_POS]));
+            dev->calib_param.dig_p9 =
+                (int16_t) (((int16_t) temp[BMP280_DIG_P9_MSB_POS] << 8) | ((int16_t) temp[BMP280_DIG_P9_LSB_POS]));
+        }
+    }
+
+    return rslt;
+}
+
+/*!
+ * @brief This internal API to reset the sensor, restore/set conf, restore/set mode
+ */
+static int8_t conf_sensor(uint8_t mode, const struct bmp280_config *conf, struct bmp280_dev *dev)
+{
+    int8_t rslt;
+    uint8_t temp[2] = { 0, 0 };
+    uint8_t reg_addr[2] = { BMP280_CTRL_MEAS_ADDR, BMP280_CONFIG_ADDR };
+
+    rslt = null_ptr_check(dev);
+    if ((rslt == BMP280_OK) && (conf != NULL))
+    {
+        rslt = bmp280_get_regs(BMP280_CTRL_MEAS_ADDR, temp, 2, dev);
+        if (rslt == BMP280_OK)
+        {
+            /* Here the intention is to put the device to sleep
+             * within the shortest period of time
+             */
+            rslt = bmp280_soft_reset(dev);
+            if (rslt == BMP280_OK)
+            {
+                temp[0] = BMP280_SET_BITS(temp[0], BMP280_OS_TEMP, conf->os_temp);
+                temp[0] = BMP280_SET_BITS(temp[0], BMP280_OS_PRES, conf->os_pres);
+                temp[1] = BMP280_SET_BITS(temp[1], BMP280_STANDBY_DURN, conf->odr);
+                temp[1] = BMP280_SET_BITS(temp[1], BMP280_FILTER, conf->filter);
+                temp[1] = BMP280_SET_BITS_POS_0(temp[1], BMP280_SPI3_ENABLE, conf->spi3w_en);
+                rslt = bmp280_set_regs(reg_addr, temp, 2, dev);
+                if (rslt == BMP280_OK)
+                {
+                    dev->conf = *conf;
+                    if (mode != BMP280_SLEEP_MODE)
+                    {
+                        /* Write only the power mode register in a separate write */
+                        temp[0] = BMP280_SET_BITS_POS_0(temp[0], BMP280_POWER_MODE, mode);
+                        rslt = bmp280_set_regs(reg_addr, temp, 1, dev);
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        rslt = BMP280_E_NULL_PTR;
+    }
+
+    return rslt;
+}
+
+/*!
+ * @This internal API checks whether the uncompensated temperature and pressure are within the range
+ */
+static int8_t st_check_boundaries(int32_t utemperature, int32_t upressure)
+{
+    int8_t rslt = 0;
+
+    /* check UT and UP for valid range */
+    if ((utemperature <= BMP280_ST_ADC_T_MIN || utemperature >= BMP280_ST_ADC_T_MAX) &&
+        (upressure <= BMP280_ST_ADC_P_MIN || upressure >= BMP280_ST_ADC_P_MAX))
+    {
+        rslt = BMP280_E_UNCOMP_TEMP_AND_PRESS_RANGE;
+    }
+    else if (utemperature <= BMP280_ST_ADC_T_MIN || utemperature >= BMP280_ST_ADC_T_MAX)
+    {
+        rslt = BMP280_E_UNCOMP_TEMP_RANGE;
+    }
+    else if (upressure <= BMP280_ST_ADC_P_MIN || upressure >= BMP280_ST_ADC_P_MAX)
+    {
+        rslt = BMP280_E_UNCOMP_PRES_RANGE;
+    }
+    else
+    {
+        rslt = BMP280_OK;
+    }
+
+    return rslt;
+}

--- a/C_Controller/platforms/recovid_revB/bmp280.h
+++ b/C_Controller/platforms/recovid_revB/bmp280.h
@@ -1,0 +1,287 @@
+/**
+* Copyright (c) 2020 Bosch Sensortec GmbH. All rights reserved.
+*
+* BSD-3-Clause
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+* IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* @file	bmp280.h
+* @date	2020-01-10
+* @version	v3.3.4
+*
+*/#ifndef __BMP280_H__
+#define __BMP280_H__
+
+#include "bmp280_defs.h"
+
+/*! CPP guard */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * @brief This API reads the data from the given register address of the
+ * sensor.
+ *
+ * @param[in] reg_addr : Register address from where the data to be read
+ * @param[out] reg_data : Pointer to data buffer to store the read data.
+ * @param[in] len : No of bytes of data to be read.
+ * @param[in] dev : Structure instance of bmp280_dev.
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint8_t len, const struct bmp280_dev *dev);
+
+/*!
+ * @brief This API writes the given data to the register addresses
+ * of the sensor.
+ *
+ * @param[in] reg_addr : Register address from where the data to be written.
+ * @param[in] reg_data : Pointer to data buffer which is to be written
+ * in the sensor.
+ * @param[in] len : No of bytes of data to write..
+ * @param[in] dev : Structure instance of bmp280_dev.
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_set_regs(uint8_t *reg_addr, const uint8_t *reg_data, uint8_t len, const struct bmp280_dev *dev);
+
+/*!
+ * @brief This API triggers the soft reset of the sensor.
+ *
+ * @param[in] dev : Structure instance of bmp280_dev.
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise..
+ */
+int8_t bmp280_soft_reset(const struct bmp280_dev *dev);
+
+/*!
+ *  @brief This API is the entry point.
+ *  It reads the chip-id and calibration data from the sensor.
+ *
+ *  @param[in,out] dev : Structure instance of bmp280_dev
+ *
+ *  @return Result of API execution
+ *  @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+int8_t bmp280_init(struct bmp280_dev *dev);
+
+/*!
+ * @brief This API reads the data from the ctrl_meas register and config
+ * register. It gives the currently set temperature and pressure over-sampling
+ * configuration, power mode configuration, sleep duration and
+ * IIR filter coefficient.
+ *
+ * @param[out] conf : Current configuration of the bmp280
+ * conf.osrs_t, conf.osrs_p = BMP280_OS_NONE, BMP280_OS_1X,
+ *     BMP280_OS_2X, BMP280_OS_4X, BMP280_OS_8X, BMP280_OS_16X
+ * conf.odr = BMP280_ODR_0_5_MS, BMP280_ODR_62_5_MS, BMP280_ODR_125_MS,
+ *     BMP280_ODR_250_MS, BMP280_ODR_500_MS, BMP280_ODR_1000_MS,
+ *     BMP280_ODR_2000_MS, BMP280_ODR_4000_MS
+ * conf.filter = BMP280_FILTER_OFF, BMP280_FILTER_COEFF_2,
+ *     BMP280_FILTER_COEFF_4, BMP280_FILTER_COEFF_8, BMP280_FILTER_COEFF_16
+ * conf.spi3w_en = BMP280_SPI3_WIRE_ENABLE, BMP280_SPI3_WIRE_DISABLE
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_config(struct bmp280_config *conf, struct bmp280_dev *dev);
+
+/*!
+ * @brief This API writes the data to the ctrl_meas register and config register.
+ * It sets the temperature and pressure over-sampling configuration,
+ * power mode configuration, sleep duration and IIR filter coefficient.
+ *
+ * @param[in] conf : Desired configuration to the bmp280
+ * conf.osrs_t, conf.osrs_p = BMP280_OS_NONE, BMP280_OS_1X,
+ *     BMP280_OS_2X, BMP280_OS_4X, BMP280_OS_8X, BMP280_OS_16X
+ * conf.odr = BMP280_ODR_0_5_MS, BMP280_ODR_62_5_MS, BMP280_ODR_125_MS,
+ *     BMP280_ODR_250_MS, BMP280_ODR_500_MS, BMP280_ODR_1000_MS,
+ *     BMP280_ODR_2000_MS, BMP280_ODR_4000_MS
+ * conf.filter = BMP280_FILTER_OFF, BMP280_FILTER_COEFF_2,
+ *     BMP280_FILTER_COEFF_4, BMP280_FILTER_COEFF_8, BMP280_FILTER_COEFF_16
+ * conf.spi3w_en = BMP280_SPI3_WIRE_ENABLE, BMP280_SPI3_WIRE_DISABLE
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_set_config(const struct bmp280_config *conf, struct bmp280_dev *dev);
+
+/*!
+ * @brief This API reads the status register
+ *
+ * @param[out] status : Status of the sensor
+ * status.measuring = BMP280_MEAS_DONE, BMP280_MEAS_ONGOING
+ * status.im_update = BMP280_IM_UPDATE_DONE, BMP280_IM_UPDATE_ONGOING
+ * @param[in] dev : structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_status(struct bmp280_status *status, const struct bmp280_dev *dev);
+
+/*!
+ * @brief This API reads the power mode.
+ *
+ * @param[out] mode : BMP280_SLEEP_MODE, BMP280_NORMAL_MODE,
+ *     BMP280_FORCED_MODE
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_power_mode(uint8_t *mode, const struct bmp280_dev *dev);
+
+/*!
+ * @brief This API writes the power mode.
+ *
+ * @param[out] mode : BMP280_SLEEP_MODE, BMP280_NORMAL_MODE,
+ *     BMP280_FORCED_MODE
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_set_power_mode(uint8_t mode, struct bmp280_dev *dev);
+
+/*!
+ * @brief This API reads the temperature and pressure data registers.
+ * It gives the raw temperature and pressure data.
+ *
+ * @param[in] uncomp_data : Structure instance of bmp280_uncomp_data
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_uncomp_data(struct bmp280_uncomp_data *uncomp_data, const struct bmp280_dev *dev);
+
+/*!
+ * @brief This API is used to get the compensated temperature from
+ * uncompensated temperature. This API uses 32 bit integers.
+ * Temperature in degC, resolution is 0.01 DegC. output value of
+ * "5123" equals 51.23 degree Celsius
+ *
+ * @param[out] comp_temp : 32 bit compensated temperature
+ * @param[in] uncomp_temp : Raw temperature values from the sensor
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_comp_temp_32bit(int32_t *comp_temp, int32_t uncomp_temp, struct bmp280_dev *dev);
+
+/*!
+ * @brief This API is used to get the compensated pressure from
+ * uncompensated pressure. This API uses 32 bit integers.
+ * Pressure in Pa as unsigned 32 bit integer
+ * output value of "96386" equals 96386 Pa = 963.86 hPa
+ *
+ * @param[out] comp_pres : 32 bit compensated pressure
+ * @param[in] uncomp_pres : Raw pressure values from the sensor
+ * @param[in] dev : structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_comp_pres_32bit(uint32_t *comp_pres, uint32_t uncomp_pres, const struct bmp280_dev *dev);
+
+#ifndef BMP280_DISABLE_64BIT_COMPENSATION
+
+/*!
+ * @brief This API is used to get the compensated pressure from
+ * uncompensated pressure. This API uses 64 bit integers.
+ * Pressure in Pa as unsigned 32 bit integer in Q24.8 format
+ * (24 integer bits and 8 fractional bits). Output value of "24674867"
+ * represents 24674867/256 = 96386.2 Pa = 963.862 hPa
+ *
+ * @param[out] pressure : compensated pressure
+ * @param[in] uncomp_pres : Raw pressure values from the sensor
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_comp_pres_64bit(uint32_t *pressure, uint32_t uncomp_pres, const struct bmp280_dev *dev);
+
+#endif /* BMP280_DISABLE_64BIT_COMPENSATION */
+
+#ifndef BMP280_DISABLE_DOUBLE_COMPENSATION
+
+/*!
+ * @brief This API is used to get the compensated temperature from
+ * uncompensated temperature. This API uses double floating precision.
+ * Temperature in degree Celsius , double precision. output value
+ * of "51.23" equals 51.23 degC.
+ *
+ * @param[out] temperature : compensated temperature
+ * @param[in] uncomp_temp : Raw temperature values from the sensor
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_comp_temp_double(double *temperature, int32_t uncomp_temp, struct bmp280_dev *dev);
+
+/*!
+ * @brief This API is used to get the compensated pressure from
+ * uncompensated pressure. This API uses double floating precision.
+ * Pressure in Pa as double. Output value of "96386.2"
+ * equals 96386.2 Pa = 963.862 hPa
+ *
+ * @param[out] pressure : compensated pressure
+ * @param[in] uncomp_pres : Raw pressure values from the sensor
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Result of API execution
+ * @retval Zero for Success, non-zero otherwise.
+ */
+int8_t bmp280_get_comp_pres_double(double *pressure, uint32_t uncomp_pres, const struct bmp280_dev *dev);
+
+#endif /* BMP280_DISABLE_DOUBLE_COMPENSATION */
+
+/*!
+ * @brief This API computes the measurement time in milliseconds for the
+ * active configuration
+ *
+ * @param[in] dev : Structure instance of bmp280_dev
+ *
+ * @return Measurement time for the active configuration in milliseconds
+ */
+uint8_t bmp280_compute_meas_time(const struct bmp280_dev *dev);
+
+#ifdef __cplusplus
+}
+#endif /* End of CPP guard */
+
+#endif /* _BMP280_H_ */

--- a/C_Controller/platforms/recovid_revB/bmp280_defs.h
+++ b/C_Controller/platforms/recovid_revB/bmp280_defs.h
@@ -1,0 +1,404 @@
+/**
+* Copyright (c) 2020 Bosch Sensortec GmbH. All rights reserved.
+*
+* BSD-3-Clause
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+* IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* @file	bmp280_defs.h
+* @date	2020-01-10
+* @version	v3.3.4
+*
+*/#ifndef __BMP280_DEFS_H__
+#define __BMP280_DEFS_H__
+
+/*! CPP guard */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/****************************************************************/
+/*! @name       Header includes             */
+/****************************************************************/
+#ifdef __KERNEL__
+#include <linux/types.h>
+#include <linux/kernel.h>
+#else
+#include <stdint.h>
+#include <stddef.h>
+#endif
+
+/****************************************************************/
+/*! @name       Common macros               */
+/****************************************************************/
+#ifdef __KERNEL__
+#if !defined(UINT8_C) && !defined(INT8_C)
+#define INT8_C(x)   S8_C(x)
+#define UINT8_C(x)  U8_C(x)
+#endif
+
+#if !defined(UINT16_C) && !defined(INT16_C)
+#define INT16_C(x)  S16_C(x)
+#define UINT16_C(x) U16_C(x)
+#endif
+
+#if !defined(INT32_C) && !defined(UINT32_C)
+#define INT32_C(x)  S32_C(x)
+#define UINT32_C(x) U32_C(x)
+#endif
+
+#if !defined(INT64_C) && !defined(UINT64_C)
+#define INT64_C(x)  S64_C(x)
+#define UINT64_C(x) U64_C(x)
+#endif
+#endif
+
+/*! @name C standard macros */
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL 0
+#else
+#define NULL ((void *) 0)
+#endif
+#endif
+
+/****************************************************************/
+/*! @name       BMP280 Macros               */
+/****************************************************************/
+
+/*! @name Macro to disable double precision floating point compensation
+ * @note Uncomment the following line to disable it
+ */
+#ifndef BMP280_DISABLE_DOUBLE_COMPENSATION
+
+/* #define BMP280_DISABLE_DOUBLE_COMPENSATION */
+#endif
+
+/*! @name Macro to disable 64bit compensation
+ * @note Uncomment the following line to disable it
+ */
+#ifndef BMP280_DISABLE_64BIT_COMPENSATION
+
+/* #define BMP280_DISABLE_64BIT_COMPENSATION */
+#endif
+
+/*! @name Interface selection macros */
+#define BMP280_SPI_INTF                      UINT8_C(0)
+#define BMP280_I2C_INTF                      UINT8_C(1)
+
+/*! @name Return codes */
+/*! @name Success code*/
+#define BMP280_OK                            INT8_C(0)
+#define BMP280_BOND_WIRE_OK                  INT8_C(0)
+
+/*! @name Error codes */
+#define BMP280_E_NULL_PTR                    INT8_C(-1)
+#define BMP280_E_DEV_NOT_FOUND               INT8_C(-2)
+#define BMP280_E_INVALID_LEN                 INT8_C(-3)
+#define BMP280_E_COMM_FAIL                   INT8_C(-4)
+#define BMP280_E_INVALID_MODE                INT8_C(-5)
+#define BMP280_E_BOND_WIRE                   INT8_C(-6)
+#define BMP280_E_IMPLAUS_TEMP                INT8_C(-7)
+#define BMP280_E_IMPLAUS_PRESS               INT8_C(-8)
+#define BMP280_E_CAL_PARAM_RANGE             INT8_C(-9)
+#define BMP280_E_UNCOMP_TEMP_RANGE           INT8_C(-10)
+#define BMP280_E_UNCOMP_PRES_RANGE           INT8_C(-11)
+#define BMP280_E_UNCOMP_TEMP_AND_PRESS_RANGE INT8_C(-12)
+#define BMP280_E_UNCOMP_DATA_CALC            INT8_C(-13)
+#define BMP280_E_32BIT_COMP_TEMP             INT8_C(-14)
+#define BMP280_E_32BIT_COMP_PRESS            INT8_C(-15)
+#define BMP280_E_64BIT_COMP_PRESS            INT8_C(-16)
+#define BMP280_E_DOUBLE_COMP_TEMP            INT8_C(-17)
+#define BMP280_E_DOUBLE_COMP_PRESS           INT8_C(-18)
+
+/*! @name Chip IDs for samples and mass production parts */
+#define BMP280_CHIP_ID1                      UINT8_C(0x56)
+#define BMP280_CHIP_ID2                      UINT8_C(0x57)
+#define BMP280_CHIP_ID3                      UINT8_C(0x58)
+
+/*! @name I2C addresses */
+#define BMP280_I2C_ADDR_PRIM                 UINT8_C(0x76)
+#define BMP280_I2C_ADDR_SEC                  UINT8_C(0x77)
+
+/*! @name Calibration parameter register addresses*/
+#define BMP280_DIG_T1_LSB_ADDR               UINT8_C(0x88)
+#define BMP280_DIG_T1_MSB_ADDR               UINT8_C(0x89)
+#define BMP280_DIG_T2_LSB_ADDR               UINT8_C(0x8A)
+#define BMP280_DIG_T2_MSB_ADDR               UINT8_C(0x8B)
+#define BMP280_DIG_T3_LSB_ADDR               UINT8_C(0x8C)
+#define BMP280_DIG_T3_MSB_ADDR               UINT8_C(0x8D)
+#define BMP280_DIG_P1_LSB_ADDR               UINT8_C(0x8E)
+#define BMP280_DIG_P1_MSB_ADDR               UINT8_C(0x8F)
+#define BMP280_DIG_P2_LSB_ADDR               UINT8_C(0x90)
+#define BMP280_DIG_P2_MSB_ADDR               UINT8_C(0x91)
+#define BMP280_DIG_P3_LSB_ADDR               UINT8_C(0x92)
+#define BMP280_DIG_P3_MSB_ADDR               UINT8_C(0x93)
+#define BMP280_DIG_P4_LSB_ADDR               UINT8_C(0x94)
+#define BMP280_DIG_P4_MSB_ADDR               UINT8_C(0x95)
+#define BMP280_DIG_P5_LSB_ADDR               UINT8_C(0x96)
+#define BMP280_DIG_P5_MSB_ADDR               UINT8_C(0x97)
+#define BMP280_DIG_P6_LSB_ADDR               UINT8_C(0x98)
+#define BMP280_DIG_P6_MSB_ADDR               UINT8_C(0x99)
+#define BMP280_DIG_P7_LSB_ADDR               UINT8_C(0x9A)
+#define BMP280_DIG_P7_MSB_ADDR               UINT8_C(0x9B)
+#define BMP280_DIG_P8_LSB_ADDR               UINT8_C(0x9C)
+#define BMP280_DIG_P8_MSB_ADDR               UINT8_C(0x9D)
+#define BMP280_DIG_P9_LSB_ADDR               UINT8_C(0x9E)
+#define BMP280_DIG_P9_MSB_ADDR               UINT8_C(0x9F)
+
+/*! @name Other registers */
+#define BMP280_CHIP_ID_ADDR                  UINT8_C(0xD0)
+#define BMP280_SOFT_RESET_ADDR               UINT8_C(0xE0)
+#define BMP280_STATUS_ADDR                   UINT8_C(0xF3)
+#define BMP280_CTRL_MEAS_ADDR                UINT8_C(0xF4)
+#define BMP280_CONFIG_ADDR                   UINT8_C(0xF5)
+#define BMP280_PRES_MSB_ADDR                 UINT8_C(0xF7)
+#define BMP280_PRES_LSB_ADDR                 UINT8_C(0xF8)
+#define BMP280_PRES_XLSB_ADDR                UINT8_C(0xF9)
+#define BMP280_TEMP_MSB_ADDR                 UINT8_C(0xFA)
+#define BMP280_TEMP_LSB_ADDR                 UINT8_C(0xFB)
+#define BMP280_TEMP_XLSB_ADDR                UINT8_C(0xFC)
+
+/*! @name Power modes */
+#define BMP280_SLEEP_MODE                    UINT8_C(0x00)
+#define BMP280_FORCED_MODE                   UINT8_C(0x01)
+#define BMP280_NORMAL_MODE                   UINT8_C(0x03)
+
+/*! @name Soft reset command */
+#define BMP280_SOFT_RESET_CMD                UINT8_C(0xB6)
+
+/*! @name ODR options */
+#define BMP280_ODR_0_5_MS                    UINT8_C(0x00)
+#define BMP280_ODR_62_5_MS                   UINT8_C(0x01)
+#define BMP280_ODR_125_MS                    UINT8_C(0x02)
+#define BMP280_ODR_250_MS                    UINT8_C(0x03)
+#define BMP280_ODR_500_MS                    UINT8_C(0x04)
+#define BMP280_ODR_1000_MS                   UINT8_C(0x05)
+#define BMP280_ODR_2000_MS                   UINT8_C(0x06)
+#define BMP280_ODR_4000_MS                   UINT8_C(0x07)
+
+/*! @name Over-sampling macros */
+#define BMP280_OS_NONE                       UINT8_C(0x00)
+#define BMP280_OS_1X                         UINT8_C(0x01)
+#define BMP280_OS_2X                         UINT8_C(0x02)
+#define BMP280_OS_4X                         UINT8_C(0x03)
+#define BMP280_OS_8X                         UINT8_C(0x04)
+#define BMP280_OS_16X                        UINT8_C(0x05)
+
+/*! @name Filter coefficient macros */
+#define BMP280_FILTER_OFF                    UINT8_C(0x00)
+#define BMP280_FILTER_COEFF_2                UINT8_C(0x01)
+#define BMP280_FILTER_COEFF_4                UINT8_C(0x02)
+#define BMP280_FILTER_COEFF_8                UINT8_C(0x03)
+#define BMP280_FILTER_COEFF_16               UINT8_C(0x04)
+
+/*! @name SPI 3-Wire macros */
+#define BMP280_SPI3_WIRE_ENABLE              UINT8_C(1)
+#define BMP280_SPI3_WIRE_DISABLE             UINT8_C(0)
+
+/*! @name Measurement status */
+#define BMP280_MEAS_DONE                     UINT8_C(0)
+#define BMP280_MEAS_ONGOING                  UINT8_C(1)
+
+/*! @name Image update */
+#define BMP280_IM_UPDATE_DONE                UINT8_C(0)
+#define BMP280_IM_UPDATE_ONGOING             UINT8_C(1)
+
+/*! @name Position and mask macros */
+#define BMP280_STATUS_IM_UPDATE_POS          UINT8_C(0)
+#define BMP280_STATUS_IM_UPDATE_MASK         UINT8_C(0x01)
+#define BMP280_STATUS_MEAS_POS               UINT8_C(3)
+#define BMP280_STATUS_MEAS_MASK              UINT8_C(0x08)
+#define BMP280_OS_TEMP_POS                   UINT8_C(5)
+#define BMP280_OS_TEMP_MASK                  UINT8_C(0xE0)
+#define BMP280_OS_PRES_POS                   UINT8_C(2)
+#define BMP280_OS_PRES_MASK                  UINT8_C(0x1C)
+#define BMP280_POWER_MODE_POS                UINT8_C(0)
+#define BMP280_POWER_MODE_MASK               UINT8_C(0x03)
+#define BMP280_STANDBY_DURN_POS              UINT8_C(5)
+#define BMP280_STANDBY_DURN_MASK             UINT8_C(0xE0)
+#define BMP280_FILTER_POS                    UINT8_C(2)
+#define BMP280_FILTER_MASK                   UINT8_C(0x1C)
+#define BMP280_SPI3_ENABLE_POS               UINT8_C(0)
+#define BMP280_SPI3_ENABLE_MASK              UINT8_C(0x01)
+
+/*! @name Calibration parameters' relative position */
+#define BMP280_DIG_T1_LSB_POS                UINT8_C(0)
+#define BMP280_DIG_T1_MSB_POS                UINT8_C(1)
+#define BMP280_DIG_T2_LSB_POS                UINT8_C(2)
+#define BMP280_DIG_T2_MSB_POS                UINT8_C(3)
+#define BMP280_DIG_T3_LSB_POS                UINT8_C(4)
+#define BMP280_DIG_T3_MSB_POS                UINT8_C(5)
+#define BMP280_DIG_P1_LSB_POS                UINT8_C(6)
+#define BMP280_DIG_P1_MSB_POS                UINT8_C(7)
+#define BMP280_DIG_P2_LSB_POS                UINT8_C(8)
+#define BMP280_DIG_P2_MSB_POS                UINT8_C(9)
+#define BMP280_DIG_P3_LSB_POS                UINT8_C(10)
+#define BMP280_DIG_P3_MSB_POS                UINT8_C(11)
+#define BMP280_DIG_P4_LSB_POS                UINT8_C(12)
+#define BMP280_DIG_P4_MSB_POS                UINT8_C(13)
+#define BMP280_DIG_P5_LSB_POS                UINT8_C(14)
+#define BMP280_DIG_P5_MSB_POS                UINT8_C(15)
+#define BMP280_DIG_P6_LSB_POS                UINT8_C(16)
+#define BMP280_DIG_P6_MSB_POS                UINT8_C(17)
+#define BMP280_DIG_P7_LSB_POS                UINT8_C(18)
+#define BMP280_DIG_P7_MSB_POS                UINT8_C(19)
+#define BMP280_DIG_P8_LSB_POS                UINT8_C(20)
+#define BMP280_DIG_P8_MSB_POS                UINT8_C(21)
+#define BMP280_DIG_P9_LSB_POS                UINT8_C(22)
+#define BMP280_DIG_P9_MSB_POS                UINT8_C(23)
+#define BMP280_CALIB_DATA_SIZE               UINT8_C(24)
+
+/*! @name Bit-slicing macros */
+#define BMP280_GET_BITS(bitname, x)                    ((x & bitname##_MASK) \
+                                                        >> bitname##_POS)
+#define BMP280_SET_BITS(regvar, bitname, val)          ((regvar & \
+                                                         ~bitname##_MASK) | ((val << bitname##_POS) & bitname##_MASK))
+#define BMP280_SET_BITS_POS_0(reg_data, bitname, data) ((reg_data & \
+                                                         ~(bitname##_MASK)) | (data & bitname##_MASK))
+#define BMP280_GET_BITS_POS_0(bitname, reg_data)       (reg_data & \
+                                                        (bitname##_MASK))
+
+/*! @brief Macros holding the minimum and maximum for trimming values */
+
+#define BMP280_ST_DIG_T1_MIN UINT16_C(19000)
+#define BMP280_ST_DIG_T1_MAX UINT16_C(35000)
+#define BMP280_ST_DIG_T2_MIN UINT16_C(22000)
+#define BMP280_ST_DIG_T2_MAX UINT16_C(30000)
+#define BMP280_ST_DIG_T3_MIN INT16_C(-3000)
+#define BMP280_ST_DIG_T3_MAX INT16_C(-1000)
+#define BMP280_ST_DIG_P1_MIN UINT16_C(30000)
+#define BMP280_ST_DIG_P1_MAX UINT16_C(42000)
+#define BMP280_ST_DIG_P2_MIN INT16_C(-12970)
+#define BMP280_ST_DIG_P2_MAX INT16_C(-8000)
+#define BMP280_ST_DIG_P3_MIN INT16_C(-5000)
+#define BMP280_ST_DIG_P3_MAX UINT16_C(8000)
+#define BMP280_ST_DIG_P4_MIN INT16_C(-10000)
+#define BMP280_ST_DIG_P4_MAX UINT16_C(18000)
+#define BMP280_ST_DIG_P5_MIN INT16_C(-500)
+#define BMP280_ST_DIG_P5_MAX UINT16_C(1100)
+#define BMP280_ST_DIG_P6_MIN INT16_C(-1000)
+#define BMP280_ST_DIG_P6_MAX UINT16_C(1000)
+#define BMP280_ST_DIG_P7_MIN INT16_C(-32768)
+#define BMP280_ST_DIG_P7_MAX UINT16_C(32767)
+#define BMP280_ST_DIG_P8_MIN INT16_C(-30000)
+#define BMP280_ST_DIG_P8_MAX UINT16_C(10000)
+#define BMP280_ST_DIG_P9_MIN INT16_C(-10000)
+#define BMP280_ST_DIG_P9_MAX UINT16_C(30000)
+
+#define BMP280_GET_BITSLICE(regvar, bitname) \
+    ((regvar & bitname##__MSK) >> bitname##__POS)
+
+/*! @brief Macros to read out API revision number */
+/*Register holding custom trimming values */
+#define BMP280_ST_TRIMCUSTOM_REG             UINT8_C(0x87)
+#define BMP280_ST_TRIMCUSTOM_REG_APIREV__POS UINT8_C(1)
+#define BMP280_ST_TRIMCUSTOM_REG_APIREV__MSK UINT8_C(0x06)
+#define BMP280_ST_TRIMCUSTOM_REG_APIREV__LEN UINT8_C(2)
+#define BMP280_ST_TRIMCUSTOM_REG_APIREV__REG BMP280_ST_TRIMCUSTOM_REG
+
+/* highest API revision supported is revision 0. */
+#define BMP280_ST_MAX_APIREVISION            UINT8_C(0x00)
+
+/*! @brief Macros holding the minimum and maximum for trimming values */
+/* 0x00000 is minimum output value */
+#define BMP280_ST_ADC_T_MIN                  INT32_C(0x00000)
+
+/* 0xFFFF0 is maximum 20-bit output value without over sampling */
+#define BMP280_ST_ADC_T_MAX                  INT32_C(0xFFFF0)
+
+/* 0x00000 is minimum output value */
+#define BMP280_ST_ADC_P_MIN                  INT32_C(0x00000)
+
+/* 0xFFFF0 is maximum 20-bit output value without over sampling */
+#define BMP280_ST_ADC_P_MAX                  INT32_C(0xFFFF0)
+
+/*! @name Function pointer type definitions */
+typedef int8_t (*bmp280_com_fptr_t)(uint8_t dev_id, uint8_t reg_addr, uint8_t *data, uint16_t len);
+typedef void (*bmp280_delay_fptr_t)(uint32_t period);
+
+/*! @name Calibration parameters' structure */
+struct bmp280_calib_param
+{
+    uint16_t dig_t1;
+    int16_t dig_t2;
+    int16_t dig_t3;
+    uint16_t dig_p1;
+    int16_t dig_p2;
+    int16_t dig_p3;
+    int16_t dig_p4;
+    int16_t dig_p5;
+    int16_t dig_p6;
+    int16_t dig_p7;
+    int16_t dig_p8;
+    int16_t dig_p9;
+    int32_t t_fine;
+};
+
+/*! @name Sensor configuration structure */
+struct bmp280_config
+{
+    uint8_t os_temp;
+    uint8_t os_pres;
+    uint8_t odr;
+    uint8_t filter;
+    uint8_t spi3w_en;
+};
+
+/*! @name Sensor status structure */
+struct bmp280_status
+{
+    uint8_t measuring;
+    uint8_t im_update;
+};
+
+/*! @name Uncompensated data structure */
+struct bmp280_uncomp_data
+{
+    int32_t uncomp_temp;
+    uint32_t uncomp_press;
+};
+
+/*! @name API device structure */
+struct bmp280_dev
+{
+    uint8_t chip_id;
+    uint8_t dev_id;
+    uint8_t intf;
+    bmp280_com_fptr_t read;
+    bmp280_com_fptr_t write;
+    bmp280_delay_fptr_t delay_ms;
+    struct bmp280_calib_param calib_param;
+    struct bmp280_config conf;
+};
+
+#ifdef __cplusplus
+}
+#endif /* End of CPP guard */
+
+#endif /* __BMP280_DEFS_H__ */

--- a/C_Controller/platforms/recovid_revB/motor.c
+++ b/C_Controller/platforms/recovid_revB/motor.c
@@ -30,7 +30,7 @@ bool motor_release() {
   return true;
 }
 
-bool motor_press(uint16_t* steps_profile_us, uint16_t nb_steps)
+bool motor_press(uint32_t* steps_profile_us, unsigned int nb_steps)
 {   
     motor_stop();
     if (nb_steps > 0) {
@@ -41,7 +41,7 @@ bool motor_press(uint16_t* steps_profile_us, uint16_t nb_steps)
         HAL_TIM_Base_Init(_motor_tim);
         HAL_DMA_Init(_motor_tim->hdma[TIM_DMA_ID_UPDATE]);
         HAL_TIM_PWM_Start_IT(_motor_tim, MOTOR_TIM_CHANNEL);
-        HAL_TIM_DMABurst_MultiWriteStart(_motor_tim, TIM_DMABASE_ARR, TIM_DMA_UPDATE,	(uint32_t*)&steps_profile_us[1], TIM_DMABURSTLENGTH_1TRANSFER, nb_steps-1);
+        HAL_TIM_DMABurst_MultiWriteStart(_motor_tim, TIM_DMABASE_ARR, TIM_DMA_UPDATE,	&steps_profile_us[1], TIM_DMABURSTLENGTH_1TRANSFER, nb_steps-1);
     }
     return true;
 }

--- a/C_Controller/platforms/recovid_revB/platform_config.h
+++ b/C_Controller/platforms/recovid_revB/platform_config.h
@@ -1,8 +1,12 @@
 #ifndef __PLATFORM_CONFIG_H__
 #define __PLATFORM_CONFIG_H__
 
-#define MAX_MOTOR_STEPS         (                                 4800)
-#define MOTOR_STEP_TIME_INIT    (                                  400)
-#define MOTOR_ACC_STEPS         (                                    2)
-#define MOTOR_ACC_COEF          (MOTOR_STEP_TIME_INIT/ MOTOR_ACC_STEPS)
+#define MOTOR_CORRECTION_USTEPS (                                   1   )
+#define MOTOR_STEP_TIME_INIT    (      400* ( MOTOR_CORRECTION_USTEPS)  )
+#define MOTOR_ACC_STEPS         (        2* ( MOTOR_CORRECTION_USTEPS)  )
+#define MOTOR_ACC_COEF          ( MOTOR_STEP_TIME_INIT/ MOTOR_ACC_STEPS )
+#define MOTOR_RELEASE_STEP_US   (      300* ( MOTOR_CORRECTION_USTEPS)  )
+#define MOTOR_HOME_STEP_US      (      400* ( MOTOR_CORRECTION_USTEPS)  )
+#define MAX_MOTOR_STEPS         (     4800/ ( MOTOR_CORRECTION_USTEPS)  )
+
 #endif

--- a/C_Controller/platforms/recovid_revB/recovid_revB.h
+++ b/C_Controller/platforms/recovid_revB/recovid_revB.h
@@ -75,8 +75,6 @@ extern UART_HandleTypeDef huart2;         // Dbg uart
 #define MOTOR_PRESS_DIR     GPIO_PIN_RESET
 #define MOTOR_RELEASE_DIR   GPIO_PIN_SET
 
-#define MOTOR_RELEASE_STEP_US   300
-#define MOTOR_HOME_STEP_US      400
 
 
 

--- a/C_Controller/platforms/recovid_revB/sensors.c
+++ b/C_Controller/platforms/recovid_revB/sensors.c
@@ -2,6 +2,24 @@
 #include "platform.h"
 #include "recovid.h"
 #include "bmp280.h"
+#include <string.h>
+
+/*
+ * Notes concernant l'utilisation du bmp280.
+ *
+ * - La fonction d'initialisation utilise directement la lib Bosch de façon synchrone.
+ *
+ * - Cette lib  n'est pas adaptée pour une utilisation asynchrone avec usage d'interruptions,
+ * la partie lecture dans la boucle principale, interroge directement le capteur sans passer par
+ * la lib pour récupérer les valeurs brutes. La compensation des valeurs est effectuée par un appel à une
+ * fonction de la lib Bosch.
+ *
+ */
+
+/* Trick : utilisation d'un masque pour timer la mesure de pression / température.
+ * Permet de gérer une durée par puissance de 2. l'unité étant 4.8ms (période de mesure du SDP610)
+ */
+#define BMP280_PERIOD 0xFFF  // une mesure toutes les 4.8 * 4095 = 19.656s
 
 typedef enum {
 	STOPPED,
@@ -9,11 +27,13 @@ typedef enum {
 	REQ_SDP_MEASUREMENT,
 	READ_SDP_MEASUREMENT,
 	READ_NPA_MEASUREMENT,
-	READ_BMP280,
+    READ_BMP280_STAGE_1,
+    READ_BMP280_STAGE_2,
 } sensors_state_t;
 
 
 static I2C_HandleTypeDef* _i2c= NULL;
+static bool initialized = false;
 
 static const uint8_t _sdp_reset_req[1]  = { 0xFE };
 static const uint8_t _sdp_readAUR_req[1]  = { 0xE5 };
@@ -24,12 +44,15 @@ static uint8_t       _sdp_measurement_buffer[3] = { 0 };
 static uint8_t       _sdp_AUR_buffer[3] 		= { 0 };
 
 static uint8_t       _npa_measurement_buffer[2]	= { 0 };
+
 static struct bmp280_dev bmp;
 struct bmp280_uncomp_data ucomp_data;
+static uint8_t bmp280_DMA_buffer[6];
 
 static volatile float _current_flow_slm;
 static volatile float _current_Patmo_mbar;
 static volatile float _current_Paw_cmH2O;
+static volatile float _current_temp_degreeC;
 static volatile float _current_vol_mL;
 static volatile	uint16_t last_sdp_t_us;
 static volatile	uint16_t last_npa_t_us;
@@ -42,47 +65,67 @@ static void process_i2c_callback(I2C_HandleTypeDef *hi2c);
 static int8_t bmp280_write_direct(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length);
 static int8_t bmp280_read_direct(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length);
 
-static int8_t bmp280_write_DMA(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length);
-static int8_t bmp280_read_DMA(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length);
-
 static void bmp280_delay_ms(uint32_t period_ms);
 //---
 
-static void initBMP280(I2C_HandleTypeDef *hi2c);
+static bool initBMP280();
+static bool initSDP610();
+static HAL_StatusTypeDef readBMP280_stage_1();
+static HAL_StatusTypeDef readBMP280_stage_2();
 
 
 
 static inline uint16_t get_time_us() { return timer_us.Instance->CNT; }
 
 static bool sensors_init(I2C_HandleTypeDef *hi2c) {
-	if (_i2c != NULL)
+	if (initialized)
 		return true;
 
+    _i2c = hi2c;
+
+    if (!initSDP610() || !initBMP280())
+        return false;
+
+    // Sensors settle time
+    HAL_Delay(100);
+
+    initialized = true;
+
+    _i2c->MasterTxCpltCallback = process_i2c_callback;
+    _i2c->MasterRxCpltCallback = process_i2c_callback;
+    _i2c->ErrorCallback = process_i2c_callback;
+
+    return true;
+}	
+
+static bool initSDP610() 
+{
+	//
 	// Scan I2C bus
 	// TODO: Check if all sensors are responding.
 	for (int t = 1; t < 127; ++t) {
-		if(HAL_I2C_IsDeviceReady(&sensors_i2c, (uint16_t)(t<<1), 2, 2) == HAL_OK) {
+		if(HAL_I2C_IsDeviceReady(_i2c, (uint16_t)(t<<1), 2, 2) == HAL_OK) {
 			dbg_printf("Found device at address: %02X\n", t);
 		}
 
 	}
 	// First try to complete pending sdp rad request if any !!!
-	if (HAL_I2C_Master_Receive(hi2c, ADDR_SPD610, (uint8_t*) _sdp_measurement_buffer, sizeof(_sdp_measurement_buffer), 1000) != HAL_I2C_ERROR_NONE) {
+	if (HAL_I2C_Master_Receive(_i2c, ADDR_SPD610, (uint8_t*) _sdp_measurement_buffer, sizeof(_sdp_measurement_buffer), 1000) != HAL_I2C_ERROR_NONE) {
 		printf("Tried to finished pending sdp read request... but nothing came...\n");
 	}
 
 	// Reset SDP
-	if (HAL_I2C_Master_Transmit(hi2c, ADDR_SPD610, (uint8_t*) _sdp_reset_req, sizeof(_sdp_reset_req), 1000) != HAL_I2C_ERROR_NONE) {
+	if (HAL_I2C_Master_Transmit(_i2c, ADDR_SPD610, (uint8_t*) _sdp_reset_req, sizeof(_sdp_reset_req), 1000) != HAL_I2C_ERROR_NONE) {
 		return false;
 	}
 
 	HAL_Delay(100);
 	// Now read sdp advanced user register
-	if (HAL_I2C_Master_Transmit(hi2c, ADDR_SPD610, (uint8_t*) _sdp_readAUR_req, sizeof(_sdp_readAUR_req), 1000) != HAL_I2C_ERROR_NONE) {
+	if (HAL_I2C_Master_Transmit(_i2c, ADDR_SPD610, (uint8_t*) _sdp_readAUR_req, sizeof(_sdp_readAUR_req), 1000) != HAL_I2C_ERROR_NONE) {
 		return false;
 	}
 	HAL_Delay(100);
-	if (HAL_I2C_Master_Receive(hi2c, ADDR_SPD610, (uint8_t*) _sdp_AUR_buffer, sizeof(_sdp_AUR_buffer), 1000) != HAL_I2C_ERROR_NONE) {
+	if (HAL_I2C_Master_Receive(_i2c, ADDR_SPD610, (uint8_t*) _sdp_AUR_buffer, sizeof(_sdp_AUR_buffer), 1000) != HAL_I2C_ERROR_NONE) {
 		return false;
 	}
 	// print AUR (Advances User Register)
@@ -92,20 +135,9 @@ static bool sensors_init(I2C_HandleTypeDef *hi2c) {
 	_sdp_writeAUR_req[1] = (uint16_t)(sdp_aur_no_i2c_hold >> 8);
 	_sdp_writeAUR_req[2] = (uint16_t)(sdp_aur_no_i2c_hold & 0xFF);
 	// Now disable i2c hold master mode
-	if (HAL_I2C_Master_Transmit(hi2c, ADDR_SPD610, (uint8_t*) _sdp_writeAUR_req, sizeof(_sdp_writeAUR_req), 1000) != HAL_I2C_ERROR_NONE) {
+	if (HAL_I2C_Master_Transmit(_i2c, ADDR_SPD610, (uint8_t*) _sdp_writeAUR_req, sizeof(_sdp_writeAUR_req), 1000) != HAL_I2C_ERROR_NONE) {
 		return false;
 	}
-
-	initBMP280(hi2c);
-
-	// Sensors settle time
-	HAL_Delay(100);
-
-	_i2c = hi2c;
-
-	_i2c->MasterTxCpltCallback = process_i2c_callback;
-	_i2c->MasterRxCpltCallback = process_i2c_callback;
-	_i2c->ErrorCallback = process_i2c_callback;
 
 	return true;
 }
@@ -115,7 +147,8 @@ bool init_sensors() {
 }
 
 
-void initBMP280(I2C_HandleTypeDef *hi2c) {
+static bool initBMP280() {
+
     struct bmp280_config conf;
 
     /* Map the delay function pointer with the function responsible for implementing the delay */
@@ -131,42 +164,37 @@ void initBMP280(I2C_HandleTypeDef *hi2c) {
     bmp.read = bmp280_read_direct;
     bmp.write = bmp280_write_direct;
 
-    /* To enable SPI interface: comment the above 4 lines and uncomment the below 4 lines */
-
-    /*
-     * bmp.dev_id = 0;
-     * bmp.read = spi_reg_read;
-     * bmp.write = spi_reg_write;
-     * bmp.intf = BMP280_SPI_INTF;
-     */
-    int8_t rslt = bmp280_init(&bmp);
-    //print_rslt(" bmp280_init status", rslt);
-
+    if (bmp280_init(&bmp) != BMP280_OK)
+        return false;
     /* Always read the current settings before writing, especially when
      * all the configuration is not modified
      */
-    rslt = bmp280_get_config(&conf, &bmp);
-    //print_rslt(" bmp280_get_config status", rslt);
+
+    if (bmp280_get_config(&conf, &bmp) != BMP280_OK)
+        return false;
 
     /* configuring the temperature oversampling, filter coefficient and output data rate */
     /* Overwrite the desired settings */
     conf.filter = BMP280_FILTER_COEFF_2;
 
+
+    /* Temperature oversampling set at 4x */
+    conf.os_temp = BMP280_OS_4X;
+   
     /* Pressure oversampling set at 4x */
     conf.os_pres = BMP280_OS_4X;
 
     /* Setting the output data rate as 1HZ(1000ms) */
     conf.odr = BMP280_ODR_1000_MS;
-    rslt = bmp280_set_config(&conf, &bmp);
-    //print_rslt(" bmp280_set_config status", rslt);
+    if (bmp280_set_config(&conf, &bmp) != BMP280_OK)
+        return false;
 
     /* Always set the power mode after setting the configuration */
-    rslt = bmp280_set_power_mode(BMP280_NORMAL_MODE, &bmp);
-    //print_rslt(" bmp280_set_power_mode status", rslt);
+    if (bmp280_set_power_mode(BMP280_NORMAL_MODE, &bmp) != BMP280_OK)
+        return false;
 
-    bmp.read = bmp280_read_DMA;
-    bmp.write = bmp280_write_DMA;
 
+    return true;
 }
 
 //! \returns false in case of hardware failure
@@ -201,6 +229,11 @@ float read_Patmo_mbar() {
   return _current_Patmo_mbar;
 }
 
+//! \returns the atmospheric pressure in mbar
+float read_temp_degreeC() {
+  return _current_temp_degreeC;
+}
+
  //! \returns the current integrated volume
 float read_Vol_mL() {
 	return _current_vol_mL;
@@ -225,33 +258,47 @@ static void readNPA() {
 	HAL_I2C_Master_Receive_DMA(_i2c, ADDR_NPA700B, (uint8_t*) _npa_measurement_buffer, sizeof(_npa_measurement_buffer));
 }
 
-static void readBMP280() {
-	_sensor_state = READ_BMP280;
-	bmp280_get_uncomp_data(&ucomp_data, &bmp);
+static HAL_StatusTypeDef readBMP280_stage_1() {
+    _sensor_state = READ_BMP280_STAGE_1;
+    bmp280_DMA_buffer[0] = BMP280_PRES_MSB_ADDR;
+    /*
+     * Envoi de l'adresse du premier registre à lire. Dans un deuxième temps (après interruption = readBMP280_stage_2), on lira la donnée
+     * Cet envoi n'est pas fait en DMA car le capteur termine la séquence par un ACK qui ne lève pas l'interruptions et
+     * qui ne permet pas de rentrer dans la machine d'état. On utilise donc la fonction d'envoi avec interruptions moins
+     * gourmande que la version synchone. (mais la version synchrone fonctionne également si besoin.)
+     */
+    return HAL_I2C_Master_Transmit_IT(_i2c, BMP280_I2C_ADDR_PRIM << 1, bmp280_DMA_buffer, 1);
+}
+
+static HAL_StatusTypeDef readBMP280_stage_2() {
+    uint8_t bytesToRead = 6;
+    assert(bytesToRead <= sizeof(bmp280_DMA_buffer));
+    _sensor_state = READ_BMP280_STAGE_2;
+    return HAL_I2C_Master_Receive_DMA(_i2c, BMP280_I2C_ADDR_PRIM << 1, bmp280_DMA_buffer, bytesToRead);
 }
 
 
 //--- BMP280 library callbacks
 
 static int8_t bmp280_write_direct(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length) {
-    return 0;
+    assert(length <= sizeof(bmp280_DMA_buffer));
+    bmp280_DMA_buffer[0] = reg_addr;
+    memcpy(bmp280_DMA_buffer + 1, reg_data, length);
+    return HAL_I2C_Master_Transmit(_i2c, i2c_addr << 1, bmp280_DMA_buffer, length + 1, 1000);
 }
 
 static int8_t bmp280_read_direct(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length) {
-    return HAL_I2C_Master_Receive(_i2c, i2c_addr, reg_data, length, 1000);
-}
-
-static int8_t bmp280_write_DMA(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length) {
-    return 0;
-}
-
-static int8_t bmp280_read_DMA(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length) {
-    return 0;
+    //--- envoi l'adresse du registre à lire
+    HAL_StatusTypeDef r = HAL_I2C_Master_Transmit(_i2c, i2c_addr << 1, &reg_addr, 1, 1000);
+    if (r != HAL_OK)
+        return r;
+    //--- réception de la donnée
+    return HAL_I2C_Master_Receive(_i2c, i2c_addr << 1, reg_data, length, 1000);
 }
 
 /**
- * Cette fonction n'est appelée par la lib bmp280 que lors de l'initialisation, cela ne pose donc
- * pas de pb de synchronisation.
+ * bmp280_delay_ms n'est appelée par la lib bmp280 que lors de l'initialisation, cela ne pose donc
+ * pas de pb de temps perdu dans le fonctionnement régulier du système.
  */
 static void bmp280_delay_ms(uint32_t period_ms) {
     HAL_Delay(period_ms);
@@ -349,22 +396,39 @@ static void process_i2c_callback(I2C_HandleTypeDef *hi2c) {
 				last_sdp_t_us = sdp_t_us;
                 readSDP();
 			} else {
-                static uint8_t count = 0;
-                if (count++ == 0)
-                    readBMP280();
+                static uint16_t count = BMP280_PERIOD;
+                if ((count++ & BMP280_PERIOD) == BMP280_PERIOD)
+                    readBMP280_stage_1();
                 else
                     readNPA();
             }
             break;
         }
-        case READ_BMP280: {
-            double pressure;
-            if (bmp280_get_comp_pres_double(&pressure, ucomp_data.uncomp_press, &bmp) != 0) {
-                // TODO: Manage error
-                _sensor_state = STOPPED;
-                break;
+        case READ_BMP280_STAGE_1: {
+            uint16_t x = BMP280_PERIOD;
+            readBMP280_stage_2();
+            break;
+        }
+        case READ_BMP280_STAGE_2: {
+            uint8_t *temp = bmp280_DMA_buffer;
+            uint32_t uncomp_press = (int32_t)((((uint32_t)(temp[0])) << 12) | (((uint32_t)(temp[1])) << 4) | ((uint32_t) temp[2] >> 4));
+            uint32_t uncomp_temp = (int32_t)((((int32_t)(temp[3])) << 12) | (((int32_t)(temp[4])) << 4) | (((int32_t)(temp[5])) >> 4));
+
+            if ((uncomp_press > BMP280_ST_ADC_P_MIN) && (uncomp_press < BMP280_ST_ADC_P_MAX)) {
+                uint32_t pressure_Pa;
+                bmp280_get_comp_pres_32bit(&pressure_Pa, uncomp_press, &bmp); // inutile de gérer l'erreur, la fonction appelée vérifie juste que bmp n'est pas null.
+				_current_Patmo_mbar = (float)pressure_Pa / 100.0;
+            } else {
+                // todo gérer l'erreur
+             }
+
+            if ((uncomp_temp > BMP280_ST_ADC_T_MIN) && (uncomp_temp < BMP280_ST_ADC_T_MAX)) {
+                int32_t temperature_degreeCx100;
+                bmp280_get_comp_temp_32bit(&temperature_degreeCx100, uncomp_temp, &bmp); // inutile de gérer l'erreur, la fonction appelée vérifie juste que bmp n'est pas null.
+				_current_temp_degreeC = (float)temperature_degreeCx100 / 100.0;
+            } else {
+                // todo gérer l'erreur
             }
-			_current_Patmo_mbar = pressure / 100;
             readNPA();
 			break;
 		}

--- a/C_Controller/platforms/recovid_revB/sensors.c
+++ b/C_Controller/platforms/recovid_revB/sensors.c
@@ -1,13 +1,15 @@
 #include "recovid_revB.h"
 #include "platform.h"
 #include "recovid.h"
+#include "bmp280.h"
 
 typedef enum {
 	STOPPED,
 	STOPPING,
 	REQ_SDP_MEASUREMENT,
 	READ_SDP_MEASUREMENT,
-	READ_NPA_MEASUREMENT
+	READ_NPA_MEASUREMENT,
+	READ_BMP280,
 } sensors_state_t;
 
 
@@ -22,8 +24,11 @@ static uint8_t       _sdp_measurement_buffer[3] = { 0 };
 static uint8_t       _sdp_AUR_buffer[3] 		= { 0 };
 
 static uint8_t       _npa_measurement_buffer[2]	= { 0 };
+static struct bmp280_dev bmp;
+struct bmp280_uncomp_data ucomp_data;
 
 static volatile float _current_flow_slm;
+static volatile float _current_Patmo_mbar;
 static volatile float _current_Paw_cmH2O;
 static volatile float _current_vol_mL;
 static volatile	uint16_t last_sdp_t_us;
@@ -32,6 +37,21 @@ volatile sensors_state_t _sensor_state;
 
 
 static void process_i2c_callback(I2C_HandleTypeDef *hi2c);
+
+//--- BMP280
+static int8_t bmp280_write_direct(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length);
+static int8_t bmp280_read_direct(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length);
+
+static int8_t bmp280_write_DMA(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length);
+static int8_t bmp280_read_DMA(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length);
+
+static void bmp280_delay_ms(uint32_t period_ms);
+//---
+
+static void initBMP280(I2C_HandleTypeDef *hi2c);
+
+
+
 static inline uint16_t get_time_us() { return timer_us.Instance->CNT; }
 
 static bool sensors_init(I2C_HandleTypeDef *hi2c) {
@@ -75,6 +95,9 @@ static bool sensors_init(I2C_HandleTypeDef *hi2c) {
 	if (HAL_I2C_Master_Transmit(hi2c, ADDR_SPD610, (uint8_t*) _sdp_writeAUR_req, sizeof(_sdp_writeAUR_req), 1000) != HAL_I2C_ERROR_NONE) {
 		return false;
 	}
+
+	initBMP280(hi2c);
+
 	// Sensors settle time
 	HAL_Delay(100);
 
@@ -89,6 +112,61 @@ static bool sensors_init(I2C_HandleTypeDef *hi2c) {
 
 bool init_sensors() {
 	return sensors_init(&sensors_i2c);
+}
+
+
+void initBMP280(I2C_HandleTypeDef *hi2c) {
+    struct bmp280_config conf;
+
+    /* Map the delay function pointer with the function responsible for implementing the delay */
+    bmp.delay_ms = bmp280_delay_ms;
+
+    /* Assign device I2C address based on the status of SDO pin (GND for PRIMARY(0x76) & VDD for SECONDARY(0x77)) */
+    bmp.dev_id = BMP280_I2C_ADDR_PRIM;
+
+    /* Select the interface mode as I2C */
+    bmp.intf = BMP280_I2C_INTF;
+
+    /* Map the I2C read & write function pointer with the functions responsible for I2C bus transfer */
+    bmp.read = bmp280_read_direct;
+    bmp.write = bmp280_write_direct;
+
+    /* To enable SPI interface: comment the above 4 lines and uncomment the below 4 lines */
+
+    /*
+     * bmp.dev_id = 0;
+     * bmp.read = spi_reg_read;
+     * bmp.write = spi_reg_write;
+     * bmp.intf = BMP280_SPI_INTF;
+     */
+    int8_t rslt = bmp280_init(&bmp);
+    //print_rslt(" bmp280_init status", rslt);
+
+    /* Always read the current settings before writing, especially when
+     * all the configuration is not modified
+     */
+    rslt = bmp280_get_config(&conf, &bmp);
+    //print_rslt(" bmp280_get_config status", rslt);
+
+    /* configuring the temperature oversampling, filter coefficient and output data rate */
+    /* Overwrite the desired settings */
+    conf.filter = BMP280_FILTER_COEFF_2;
+
+    /* Pressure oversampling set at 4x */
+    conf.os_pres = BMP280_OS_4X;
+
+    /* Setting the output data rate as 1HZ(1000ms) */
+    conf.odr = BMP280_ODR_1000_MS;
+    rslt = bmp280_set_config(&conf, &bmp);
+    //print_rslt(" bmp280_set_config status", rslt);
+
+    /* Always set the power mode after setting the configuration */
+    rslt = bmp280_set_power_mode(BMP280_NORMAL_MODE, &bmp);
+    //print_rslt(" bmp280_set_power_mode status", rslt);
+
+    bmp.read = bmp280_read_DMA;
+    bmp.write = bmp280_write_DMA;
+
 }
 
 //! \returns false in case of hardware failure
@@ -120,7 +198,7 @@ float read_Paw_cmH2O() {
 
 //! \returns the atmospheric pressure in mbar
 float read_Patmo_mbar() {
-  return 0;
+  return _current_Patmo_mbar;
 }
 
  //! \returns the current integrated volume
@@ -146,6 +224,43 @@ static void readNPA() {
 	_sensor_state = READ_NPA_MEASUREMENT;
 	HAL_I2C_Master_Receive_DMA(_i2c, ADDR_NPA700B, (uint8_t*) _npa_measurement_buffer, sizeof(_npa_measurement_buffer));
 }
+
+static void readBMP280() {
+	_sensor_state = READ_BMP280;
+	bmp280_get_uncomp_data(&ucomp_data, &bmp);
+}
+
+
+//--- BMP280 library callbacks
+
+static int8_t bmp280_write_direct(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length) {
+    return 0;
+}
+
+static int8_t bmp280_read_direct(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length) {
+    return HAL_I2C_Master_Receive(_i2c, i2c_addr, reg_data, length, 1000);
+}
+
+static int8_t bmp280_write_DMA(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length) {
+    return 0;
+}
+
+static int8_t bmp280_read_DMA(uint8_t i2c_addr, uint8_t reg_addr, uint8_t *reg_data, uint16_t length) {
+    return 0;
+}
+
+/**
+ * Cette fonction n'est appelée par la lib bmp280 que lors de l'initialisation, cela ne pose donc
+ * pas de pb de synchronisation.
+ */
+static void bmp280_delay_ms(uint32_t period_ms) {
+    HAL_Delay(period_ms);
+}
+
+//---
+
+
+
 bool sensors_start() {
     // Start the sensor state machine.
     // This state machine is managed in the I2C interupt routine.
@@ -234,8 +349,23 @@ static void process_i2c_callback(I2C_HandleTypeDef *hi2c) {
 				last_sdp_t_us = sdp_t_us;
                 readSDP();
 			} else {
-				readNPA();
-			}
+                static uint8_t count = 0;
+                if (count++ == 0)
+                    readBMP280();
+                else
+                    readNPA();
+            }
+            break;
+        }
+        case READ_BMP280: {
+            double pressure;
+            if (bmp280_get_comp_pres_double(&pressure, ucomp_data.uncomp_press, &bmp) != 0) {
+                // TODO: Manage error
+                _sensor_state = STOPPED;
+                break;
+            }
+			_current_Patmo_mbar = pressure / 100;
+            readNPA();
 			break;
 		}
 	}

--- a/C_Controller/platforms/recovid_revB/stm32f3xx_hal_msp.c
+++ b/C_Controller/platforms/recovid_revB/stm32f3xx_hal_msp.c
@@ -227,7 +227,7 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim_base)
     hdma_tim2_up.Init.PeriphInc = DMA_PINC_DISABLE;
     hdma_tim2_up.Init.MemInc = DMA_MINC_ENABLE;
     hdma_tim2_up.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-    hdma_tim2_up.Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
+    hdma_tim2_up.Init.MemDataAlignment = DMA_MDATAALIGN_WORD;
     hdma_tim2_up.Init.Mode = DMA_NORMAL;
     hdma_tim2_up.Init.Priority = DMA_PRIORITY_HIGH;
     if (HAL_DMA_Init(&hdma_tim2_up) != HAL_OK)

--- a/C_Controller/platforms/simu/lowlevel_simulation.c
+++ b/C_Controller/platforms/simu/lowlevel_simulation.c
@@ -143,7 +143,7 @@ void motor_move()
 }
 
 //Not yet implemented
-bool motor_press(uint16_t* steps_profile_us, uint16_t nb_steps)
+bool motor_press(uint32_t* steps_profile_us, unsigned int nb_steps)
 {
     return false; // TODO
 }

--- a/C_Controller/platforms/simu/platform_config.h
+++ b/C_Controller/platforms/simu/platform_config.h
@@ -1,8 +1,12 @@
 #ifndef __PLATFORM_CONFIG_H__
 #define __PLATFORM_CONFIG_H__
 
-#define MAX_MOTOR_STEPS         (                                 4800)
-#define MOTOR_STEP_TIME_INIT    (                                  400)
-#define MOTOR_ACC_STEPS         (                                    2)
-#define MOTOR_ACC_COEF          (MOTOR_STEP_TIME_INIT/ MOTOR_ACC_STEPS)
+#define MOTOR_CORRECTION_USTEPS (                                                                 1)
+#define MOTOR_STEP_TIME_INIT    (                                  400/ ( MOTOR_CORRECTION_USTEPS) )
+#define MOTOR_ACC_STEPS         (                                    2/ ( MOTOR_CORRECTION_USTEPS) )
+#define MOTOR_ACC_COEF          (MOTOR_STEP_TIME_INIT/ MOTOR_ACC_STEPS/ ( MOTOR_CORRECTION_USTEPS) )
+#define MOTOR_RELEASE_STEP_US   (                                  300/ ( MOTOR_CORRECTION_USTEPS) )
+#define MOTOR_HOME_STEP_US      (                                  400/ ( MOTOR_CORRECTION_USTEPS) )
+#define MAX_MOTOR_STEPS         (                                 4800/ ( MOTOR_CORRECTION_USTEPS) )
+
 #endif

--- a/C_Controller/src/breathing.c
+++ b/C_Controller/src/breathing.c
@@ -110,6 +110,7 @@ void breathing_run(void *args) {
 	  unsigned int _steps = 4000;
 	  //compute_constant_motor_steps(d, _steps, _motor_steps_us);
 	  compute_motor_press_christophe(350000, 2000, 65000, 20, 14, 350000, 4000, _steps, _motor_steps_us);
+	  brth_printf("T_C = %d Patmo = %d\n", (int) (read_temp_degreeC()*100), (int) (read_Patmo_mbar()*100));
 
       // Start Inhalation
       valve_inhale();

--- a/C_Controller/src/breathing.c
+++ b/C_Controller/src/breathing.c
@@ -108,8 +108,8 @@ void breathing_run(void *args) {
 
 	  uint16_t d = 300;
 	  unsigned int _steps = 4000;
-	  compute_constant_motor_steps(d, _steps, _motor_steps_us);
-	  //compute_motor_press_christophe(350000, 2000, 65000, 20, 14, 350000, 4000, _steps, _motor_steps_us); 
+	  //compute_constant_motor_steps(d, _steps, _motor_steps_us);
+	  compute_motor_press_christophe(350000, 2000, 65000, 20, 14, 350000, 4000, _steps, _motor_steps_us);
 
       // Start Inhalation
       valve_inhale();

--- a/C_Controller/src/breathing.c
+++ b/C_Controller/src/breathing.c
@@ -28,7 +28,7 @@ static uint32_t       _cycle_start_ms;
 
 
 
-static uint16_t _motor_steps_us[MAX_MOTOR_STEPS] = {0};  // TODO: Make it configurable with a define. This represent a physical limit a the system.
+static uint32_t _motor_steps_us[MAX_MOTOR_STEPS] = {0};  // TODO: Make it configurable with a define. This represent a physical limit a the system.
 static uint32_t _steps;
 
 
@@ -106,7 +106,7 @@ void breathing_run(void *args) {
       // adaptation(VM, _flow_samples, _flow_samples_count, 0.001*FLOW_SAMPLING_PERIOD_MS, &A_calibrated, &B_calibrated);
       // _flow_samples_count = 0;
 
-	  uint16_t d = 300;
+	  uint32_t d = 300;
 	  unsigned int _steps = 4000;
 	  //compute_constant_motor_steps(d, _steps, _motor_steps_us);
 	  compute_motor_press_christophe(350000, 2000, 65000, 20, 14, 350000, 4000, _steps, _motor_steps_us);

--- a/C_Controller/src/compute_motor.c
+++ b/C_Controller/src/compute_motor.c
@@ -12,11 +12,11 @@ unsigned int compute_motor_press_christophe(
 										unsigned int step_t_ns_final,
 										unsigned int dec_ns,
 										unsigned int nb_steps, 
-										uint16_t* steps_t_us)
+										uint32_t* steps_t_us)
 {
 	unsigned int step_total_us = 0;
 	unsigned int pente_acc, debit_constant, pente_dec;
-    const uint16_t max_steps = MIN(nb_steps, MAX_MOTOR_STEPS);
+    const uint32_t max_steps = MIN(nb_steps, MAX_MOTOR_STEPS);
 	for(unsigned int i = 0; i < max_steps; i++)
 	{
 
@@ -48,23 +48,27 @@ unsigned int compute_motor_press_christophe(
 	}
 	for(unsigned int i = nb_steps; i < MAX_MOTOR_STEPS; i++) 
 	{
-		steps_t_us[i] = UINT16_MAX;
+		steps_t_us[i] = UINT32_MAX;
 	}
 	return step_total_us;
 }
 
-uint32_t compute_constant_motor_steps(uint16_t step_t_us, unsigned int nb_steps, uint16_t* steps_t_us)
+
+unsigned int compute_constant_motor_steps(uint32_t step_t_us, unsigned int nb_steps, uint32_t* steps_t_us)
 {
-    const uint16_t max_steps = MIN(nb_steps, MAX_MOTOR_STEPS);
-	uint32_t total_time = 0;
+    const uint32_t max_steps = MIN(nb_steps, MAX_MOTOR_STEPS);
+	unsigned int total_time = 0;
     for(unsigned int i=0; i< MAX_MOTOR_STEPS; ++i) {
 		if(i < max_steps) {
-			   int pente_acc = ( MOTOR_STEP_TIME_INIT) - ((MOTOR_ACC_COEF)*i);
-			   steps_t_us[i] = (uint16_t) MAX(step_t_us, pente_acc);
+			   int pente_acc = (MOTOR_STEP_TIME_INIT) - ((MOTOR_ACC_COEF)*i);
+				if(pente_acc > 0)
+				   steps_t_us[i] = (uint32_t) MAX(step_t_us, pente_acc);
+				else
+				   steps_t_us[i] = step_t_us;
 		}
 		else {
 			   int pente_dec = ((MOTOR_ACC_COEF)* (i-max_steps));
-			   steps_t_us[i] = MIN(UINT16_MAX,pente_dec);
+			   steps_t_us[i] = MIN(UINT32_MAX,pente_dec);
 		}
 		total_time += step_t_us;
 	}
@@ -92,11 +96,11 @@ void print_christophe_header(
 }
 
 
-void print_steps(uint16_t* steps_t_us, unsigned int nb_steps)
+void print_steps(uint32_t* steps_t_us, unsigned int nb_steps)
 {
-    dbg_printf("Steps %d\n", nb_steps);  
+    printf("Steps %d\n", nb_steps);
 	for(unsigned int j=0; j < nb_steps; j+=1)
     {
-		dbg_printf("%d\n", steps_t_us[j]);
+		printf("%u\n", steps_t_us[j]);
     }
 }

--- a/C_Controller/src/compute_motor.c
+++ b/C_Controller/src/compute_motor.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <inttypes.h>
 #include "platform.h"
 #include "recovid.h"
 #include "compute_motor.h"
@@ -15,7 +16,7 @@ unsigned int compute_motor_press_christophe(
 										uint32_t* steps_t_us)
 {
 	unsigned int step_total_us = 0;
-	unsigned int pente_acc, debit_constant, pente_dec;
+	uint32_t pente_acc, debit_constant, pente_dec;
     const uint32_t max_steps = MIN(nb_steps, MAX_MOTOR_STEPS);
 	for(unsigned int i = 0; i < max_steps; i++)
 	{
@@ -62,12 +63,12 @@ unsigned int compute_constant_motor_steps(uint32_t step_t_us, unsigned int nb_st
 		if(i < max_steps) {
 			   int pente_acc = (MOTOR_STEP_TIME_INIT) - ((MOTOR_ACC_COEF)*i);
 				if(pente_acc > 0)
-				   steps_t_us[i] = (uint32_t) MAX(step_t_us, pente_acc);
+				   steps_t_us[i] = (uint32_t) MAX(step_t_us, (uint32_t)pente_acc);
 				else
 				   steps_t_us[i] = step_t_us;
 		}
 		else {
-			   int pente_dec = ((MOTOR_ACC_COEF)* (i-max_steps));
+			   uint32_t pente_dec = ((MOTOR_ACC_COEF)* (i-max_steps));
 			   steps_t_us[i] = MIN(UINT32_MAX,pente_dec);
 		}
 		total_time += step_t_us;
@@ -86,21 +87,21 @@ void print_christophe_header(
 										unsigned int dec_ns,
 										int nb_steps)
 {
-	dbg_printf("step_t_ns_init %d\n", step_t_ns_init);
-	dbg_printf("acc_ns %d\n", acc_ns);
-	dbg_printf("step_t_min_ns %d\n", step_t_min_ns);
-	dbg_printf("speed_down_t_ns %d\n", speed_down_t_ns);
-	dbg_printf("speed_down_t2_ps %d\n", speed_down_t2_ps);
-	dbg_printf("step_t_ns_final %d\n", step_t_ns_final);
-	dbg_printf("dec_ns %d\n", dec_ns);
+	dbg_printf("step_t_ns_init %u\n", step_t_ns_init);
+	dbg_printf("acc_ns %u\n", acc_ns);
+	dbg_printf("step_t_min_ns %u\n", step_t_min_ns);
+	dbg_printf("speed_down_t_ns %u\n", speed_down_t_ns);
+	dbg_printf("speed_down_t2_ps %u\n", speed_down_t2_ps);
+	dbg_printf("step_t_ns_final %u\n", step_t_ns_final);
+	dbg_printf("dec_ns %u\n", dec_ns);
 }
 
 
 void print_steps(uint32_t* steps_t_us, unsigned int nb_steps)
 {
-    printf("Steps %d\n", nb_steps);
+    printf("Steps %u\n", nb_steps);
 	for(unsigned int j=0; j < nb_steps; j+=1)
     {
-		printf("%u\n", steps_t_us[j]);
+		printf("%"PRIu32"\n", steps_t_us[j]);
     }
 }


### PR DESCRIPTION
Contains :
- Moving DMA to 32bits steps (usefull for disabling / modulating the microstepping)
- BMP280 sensors (thanks to @JulienDevillers )

